### PR TITLE
Added support of environs to IDEA

### DIFF
--- a/example/.run/example [main].run.xml
+++ b/example/.run/example [main].run.xml
@@ -1,0 +1,28 @@
+<component name="ProjectRunConfigurationManager">
+  <configuration default="false" name="example [main]" type="PaddleRunConfiguration" factoryName="Paddle">
+    <ExternalSystemSettings>
+      <option name="env">
+        <map>
+          <entry key="CUSTOM_ENV" value="are supported" />
+        </map>
+      </option>
+      <option name="executionName" />
+      <option name="externalProjectPath" value="$PROJECT_DIR$" />
+      <option name="externalSystemIdString" value="Paddle" />
+      <option name="scriptParameters" />
+      <option name="taskDescriptions">
+        <list />
+      </option>
+      <option name="taskNames">
+        <list>
+          <option value="main" />
+          <option value="-Ppython.run.extraArgs=&quot;arg1 arg2 arg3&quot;" />
+        </list>
+      </option>
+      <option name="vmOptions" />
+    </ExternalSystemSettings>
+    <ExternalSystemDebugServerProcess>true</ExternalSystemDebugServerProcess>
+    <ExternalSystemReattachDebugProcess>true</ExternalSystemReattachDebugProcess>
+    <method v="2" />
+  </configuration>
+</component>

--- a/example/src/main/main.py
+++ b/example/src/main/main.py
@@ -1,9 +1,11 @@
 import sys
+import os
 from bugloc.app import Bar
 
 if __name__ == '__main__':
     print(sys.path)
     print(sys.argv)
+    print(os.getenv('CUSTOM_ENV'))
     for i in range(100000000):
         pass
     print("Hello world!")

--- a/example/src/main/main.py
+++ b/example/src/main/main.py
@@ -5,7 +5,7 @@ from bugloc.app import Bar
 if __name__ == '__main__':
     print(sys.path)
     print(sys.argv)
-    print(os.getenv('CUSTOM_ENV'))
+    print(os.getenv('CUSTOM_ENV')) # You can find an example run configuration in .run folder
     for i in range(100000000):
         pass
     print("Hello world!")

--- a/idea/src/main/kotlin/io/paddle/idea/execution/state/PythonScriptCommandLineStateProvider.kt
+++ b/idea/src/main/kotlin/io/paddle/idea/execution/state/PythonScriptCommandLineStateProvider.kt
@@ -20,7 +20,8 @@ class PythonScriptCommandLineStateProvider : PaddleTaskRunProfileStateProvider<R
 
         val additionalArgsLine = (context.originalRunConfiguration as PaddleRunConfiguration).commandLine.tasksAndArguments.toList()
         val additionalArgs = Paddle.parseCliOptions(additionalArgsLine)["extraArgs"]?.trim('"', '\'') ?: ""
-        val env = context.originalRunConfiguration.settings.env + mapOf("PYTHONPATH" to task.project.environment.pythonPath)
+        val env: MutableMap<String, String> = context.originalRunConfiguration.settings.env.toMutableMap()
+        env["PYTHONPATH"] = env["PYTHONPATH"]?.plus(";${task.project.environment.pythonPath}") ?: task.project.environment.pythonPath
 
         val pythonRunConfiguration = factory.createTemplateConfiguration(context.environment.project) as PythonRunConfiguration
         pythonRunConfiguration.apply {

--- a/idea/src/main/kotlin/io/paddle/idea/execution/state/PythonScriptCommandLineStateProvider.kt
+++ b/idea/src/main/kotlin/io/paddle/idea/execution/state/PythonScriptCommandLineStateProvider.kt
@@ -20,6 +20,7 @@ class PythonScriptCommandLineStateProvider : PaddleTaskRunProfileStateProvider<R
 
         val additionalArgsLine = (context.originalRunConfiguration as PaddleRunConfiguration).commandLine.tasksAndArguments.toList()
         val additionalArgs = Paddle.parseCliOptions(additionalArgsLine)["extraArgs"]?.trim('"', '\'') ?: ""
+        val env = context.originalRunConfiguration.settings.env + mapOf("PYTHONPATH" to task.project.environment.pythonPath)
 
         val pythonRunConfiguration = factory.createTemplateConfiguration(context.environment.project) as PythonRunConfiguration
         pythonRunConfiguration.apply {
@@ -28,7 +29,7 @@ class PythonScriptCommandLineStateProvider : PaddleTaskRunProfileStateProvider<R
             sdkHome = module.pythonSdk?.homePath
             isModuleMode = task.isModuleMode
             workingDirectory = context.moduleDir.absolutePath
-            setEnvs(mapOf("PYTHONPATH" to task.project.environment.pythonPath))
+            setEnvs(env)
             setAddContentRoots(false)
             setAddSourceRoots(false)
         }


### PR DESCRIPTION
IMO, to close #52 only this is mandatory. For CLI runs we can use just the `env` command, for run test/install/... tasks in IDEA environs are supported due to the usage of external providers. 

Add an env option to `paddle.yaml`'s run section (like `args`).