### PR TITLE
TestAll task

### DIFF
--- a/plugins/python/src/main/kotlin/io/paddle/plugin/python/PythonPlugin.kt
+++ b/plugins/python/src/main/kotlin/io/paddle/plugin/python/PythonPlugin.kt
@@ -5,15 +5,14 @@ import io.paddle.plugin.python.dependencies.authentication.AuthenticationProvide
 import io.paddle.plugin.python.dependencies.index.PyPackageRepositoryIndexer
 import io.paddle.plugin.python.extensions.*
 import io.paddle.plugin.python.tasks.generate.GenerateRequirements
-import io.paddle.plugin.python.tasks.install.CiTask
-import io.paddle.plugin.python.tasks.install.InstallTask
-import io.paddle.plugin.python.tasks.install.LockTask
+import io.paddle.plugin.python.tasks.install.*
 import io.paddle.plugin.python.tasks.lint.MyPyTask
 import io.paddle.plugin.python.tasks.lint.PyLintTask
 import io.paddle.plugin.python.tasks.publish.TwinePublishTask
 import io.paddle.plugin.python.tasks.resolve.*
 import io.paddle.plugin.python.tasks.run.RunTask
 import io.paddle.plugin.python.tasks.test.PyTestTask
+import io.paddle.plugin.python.tasks.test.TestAllTask
 import io.paddle.plugin.python.tasks.venv.VenvTask
 import io.paddle.plugin.python.tasks.wheel.WheelTask
 import io.paddle.plugin.standard.extensions.plugins
@@ -46,6 +45,7 @@ object PythonPlugin : Plugin {
             WheelTask(project),
             TwinePublishTask(project),
             GenerateRequirements(project),
+            TestAllTask(project),
         ) + RunTask.from(project) + PyTestTask.from(project)
     }
 

--- a/plugins/python/src/main/kotlin/io/paddle/plugin/python/tasks/test/TestAllTask.kt
+++ b/plugins/python/src/main/kotlin/io/paddle/plugin/python/tasks/test/TestAllTask.kt
@@ -1,0 +1,17 @@
+package io.paddle.plugin.python.tasks.test
+
+import io.paddle.project.PaddleProject
+import io.paddle.tasks.Task
+import io.paddle.utils.tasks.TaskDefaultGroups
+
+class TestAllTask(project: PaddleProject) : Task(project) {
+    override val id: String
+        get() = "testAll"
+    override val group: String
+        get() = TaskDefaultGroups.TEST
+
+    override val dependencies: List<Task>
+        get() = PyTestTask.from(project)
+
+    override fun act() = Unit
+}


### PR DESCRIPTION
Simple implementation of `testAll` task: an empty task dependent on all test tasks. 

The task is not incremental since test tasks are not incremental.